### PR TITLE
Nail the RF test (Fixes #9)

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -14,6 +14,15 @@ parts +=
     i18ndude
     omelette
 
+# mr.developer settings:
+always-checkout = force
+sources = sources
+auto-checkout =
+
+[sources]
+# Test with development version of collective.cover
+collective.cover = git https://github.com/collective/collective.cover.git
+
 [code-analysis]
 recipe = plone.recipe.codeanalysis
 directory = ${buildout:directory}/src/covertile/cycle2

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -14,6 +14,9 @@ parts +=
     i18ndude
     omelette
 
+extensions +=
+    mr.developer
+
 # mr.developer settings:
 always-checkout = force
 sources = sources

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -20,7 +20,7 @@ extensions +=
 # mr.developer settings:
 always-checkout = force
 sources = sources
-auto-checkout =
+auto-checkout = *
 
 [sources]
 # Test with development version of collective.cover

--- a/src/covertile/cycle2/tests/test_carousel_tile.robot
+++ b/src/covertile/cycle2/tests/test_carousel_tile.robot
@@ -114,7 +114,7 @@ Test Carousel Tile
     # Set custom Title
     Compose Cover
     Click Link  css=${edit_link_selector}
-    Wait Until Element Is Visible  css=input.custom-title-input
+    Wait Until Element Is Visible  xpath=//div[contains(@class,"textline-sortable-element")]
     Input Text  xpath=//div[contains(@class,"textline-sortable-element")][2]//input[@class='custom-title-input']  New Title
     Click Button  Save
     Sleep  2s  Wait for carousel to load

--- a/src/covertile/cycle2/tests/test_carousel_tile.robot
+++ b/src/covertile/cycle2/tests/test_carousel_tile.robot
@@ -115,8 +115,6 @@ Test Carousel Tile
     Compose Cover
     Click Link  css=${edit_link_selector}
     Wait Until Element Is Visible  xpath=//div[contains(@class,"textline-sortable-element")]
-    Wait Until Element Is Visible  xpath=//div[contains(@class,"textline-sortable-element")][2]
-    Wait Until Element Is Visible  xpath=//div[contains(@class,"textline-sortable-element")][2]//input
     Input Text  xpath=//div[contains(@class,"textline-sortable-element")][2]//input[@class='custom-title-input']  New Title
     Click Button  Save
     Sleep  2s  Wait for carousel to load

--- a/src/covertile/cycle2/tests/test_carousel_tile.robot
+++ b/src/covertile/cycle2/tests/test_carousel_tile.robot
@@ -115,6 +115,8 @@ Test Carousel Tile
     Compose Cover
     Click Link  css=${edit_link_selector}
     Wait Until Element Is Visible  xpath=//div[contains(@class,"textline-sortable-element")]
+    Wait Until Element Is Visible  xpath=//div[contains(@class,"textline-sortable-element")][2]
+    Wait Until Element Is Visible  xpath=//div[contains(@class,"textline-sortable-element")][2]//input
     Input Text  xpath=//div[contains(@class,"textline-sortable-element")][2]//input[@class='custom-title-input']  New Title
     Click Button  Save
     Sleep  2s  Wait for carousel to load

--- a/src/covertile/cycle2/tests/test_carousel_tile.robot
+++ b/src/covertile/cycle2/tests/test_carousel_tile.robot
@@ -114,7 +114,7 @@ Test Carousel Tile
     # Set custom Title
     Compose Cover
     Click Link  css=${edit_link_selector}
-    Wait Until Element Is Visible  xpath=//div[contains(@class,"textline-sortable-element")]
+    Wait Until Element Is Visible  css=input.custom-title-input
     Input Text  xpath=//div[contains(@class,"textline-sortable-element")][2]//input[@class='custom-title-input']  New Title
     Click Button  Save
     Sleep  2s  Wait for carousel to load


### PR DESCRIPTION
Yeah!  

The problem was that I was working with dev version of c.cover locally & travis wasn't.  Travis is now using mr.developer.

@hvelarde do you think it's a good model to track dev version of collective.cover from here?
(It's easily removed of course)
