### PR TITLE
Register Javascript required for carousel tile in the JS Registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 bin/
 coverage/
 develop-eggs/
+dist/
 downloads/
 eggs/
 htmlcov/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.0a2 (unreleased)
 ------------------
 
+- Register collective.js.cycle2 resources used in this package in the JavaScript registry.
+  [djowett]
+
 - Add Dutch translations.
   [fredvd]
 

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,16 @@ Go to the 'Site Setup' page in a Plone site and click on the 'Add-ons' link.
 
 Check the box next to `covertile.cycle2` and click the 'Activate' button.
 
+
+Uninstallation
+^^^^^^^^^^^^^^
+
+This package provides an uninstall Generic Setup profile, however, it will not
+deregister the Cycle2 javascripts from the JS registry dependencies as they
+could be used by other addons. Feel free to manually uninstall these if you
+are sure that you no longer use them.
+
+
 Use
 ^^^
 

--- a/src/covertile/cycle2/profiles/default/jsregistry.xml
+++ b/src/covertile/cycle2/profiles/default/jsregistry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+  <javascript id="++resource++collective.js.cycle2/jquery.cycle2.min.js"
+      cacheable="True" compression="none" cookable="True" enabled="True"
+      expression="" inline="False" authenticated="False" />
+  <javascript id="++resource++collective.js.cycle2/jquery.cycle2.center.min.js"
+      cacheable="True" compression="none" cookable="True" enabled="True"
+      expression="" inline="False" authenticated="False" />
+  <javascript id="++resource++collective.js.cycle2/jquery.cycle2.swipe.min.js"
+      cacheable="True" compression="none" cookable="True" enabled="True"
+      expression="" inline="False" authenticated="False" />
+</object>


### PR DESCRIPTION
collective.js.cycle2 no longer does that for us (indeed it shouldn't)

This should fix #14
