### PR TITLE
Issue 23 - Fix icon path after release of collective.cover b1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ There's a frood who really knows where his towel is.
 1.0a2 (unreleased)
 ------------------
 
+- Fix icon path after release of collective.cover b1.
+  [rodfersou]
+
 - Register collective.js.cycle2 resources used in this package in the JavaScript registry.
   [djowett]
 

--- a/src/covertile/cycle2/tiles/tiles.zcml
+++ b/src/covertile/cycle2/tiles/tiles.zcml
@@ -12,7 +12,7 @@
         name="covertile.cycle2.carousel"
         title="Cycle2 Carousel Tile"
         description="A tile showing Cycle2 based carousel of images."
-        icon="++resource++collective.cover/tile-carousel.png"
+        icon="++resource++collective.cover/img/tile-carousel.png"
         add_permission="cmf.ModifyPortalContent"
         schema=".carousel.ICarouselTile"
         class=".carousel.CarouselTile"


### PR DESCRIPTION
closes #23
